### PR TITLE
Preserve field ordering from the original Conjure specs

### DIFF
--- a/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/OpenApiGenerator.java
+++ b/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/OpenApiGenerator.java
@@ -32,10 +32,10 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Discriminator;
 import io.swagger.v3.oas.models.media.Schema;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -62,7 +62,7 @@ public final class OpenApiGenerator {
                                         (_a, _b) -> {
                                             throw new IllegalStateException();
                                         },
-                                        TreeMap::new)))));
+                                        LinkedHashMap::new)))));
     }
 
     private static Stream<Entry<String, Schema<?>>> convertUnion(UnionDefinition value) {
@@ -85,7 +85,7 @@ public final class OpenApiGenerator {
                                                         (_a, _b) -> {
                                                             throw new IllegalStateException();
                                                         },
-                                                        TreeMap::new)))
+                                                        LinkedHashMap::new)))
                                         .required(List.of(
                                                 "type", elt.getFieldName().get())))),
                 Stream.of(Map.entry(
@@ -149,7 +149,7 @@ public final class OpenApiGenerator {
                                         (_a, _b) -> {
                                             throw new IllegalStateException();
                                         },
-                                        TreeMap::new))));
+                                        LinkedHashMap::new))));
     }
 
     private OpenApiGenerator() {}

--- a/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/OpenApiGenerator.java
+++ b/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/OpenApiGenerator.java
@@ -16,6 +16,7 @@
 
 package com.theoremlp.conjure.openapi;
 
+import com.google.common.collect.ImmutableMap;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.EnumDefinition;
@@ -32,11 +33,9 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Discriminator;
 import io.swagger.v3.oas.models.media.Schema;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public final class OpenApiGenerator {
@@ -56,13 +55,7 @@ public final class OpenApiGenerator {
                         .properties(value.getFields().stream()
                                 .map(elt -> Map.entry(
                                         elt.getFieldName().get(), elt.getType().accept(TYPE_VISITOR)))
-                                .collect(Collectors.toMap(
-                                        Entry::getKey,
-                                        Entry::getValue,
-                                        (_a, _b) -> {
-                                            throw new IllegalStateException();
-                                        },
-                                        LinkedHashMap::new)))));
+                                .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue)))));
     }
 
     private static Stream<Entry<String, Schema<?>>> convertUnion(UnionDefinition value) {
@@ -79,13 +72,7 @@ public final class OpenApiGenerator {
                                                                 elt.getFieldName()
                                                                         .get(),
                                                                 elt.getType().accept(TYPE_VISITOR)))
-                                                .collect(Collectors.toMap(
-                                                        Entry::getKey,
-                                                        Entry::getValue,
-                                                        (_a, _b) -> {
-                                                            throw new IllegalStateException();
-                                                        },
-                                                        LinkedHashMap::new)))
+                                                .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue)))
                                         .required(List.of(
                                                 "type", elt.getFieldName().get())))),
                 Stream.of(Map.entry(
@@ -143,13 +130,7 @@ public final class OpenApiGenerator {
                                         }
                                     });
                                 })
-                                .collect(Collectors.toMap(
-                                        Entry::getKey,
-                                        Entry::getValue,
-                                        (_a, _b) -> {
-                                            throw new IllegalStateException();
-                                        },
-                                        LinkedHashMap::new))));
+                                .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue))));
     }
 
     private OpenApiGenerator() {}

--- a/conjure-openapi/src/test/resources/map-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/map-test.openapi.yaml
@@ -12,14 +12,14 @@ components:
         - "string_field"
       type: "object"
       properties:
-        double_field:
-          type: "number"
-          format: "float"
+        string_field:
+          type: "string"
         integer_field:
           type: "integer"
           format: "int32"
-        string_field:
-          type: "string"
+        double_field:
+          type: "number"
+          format: "float"
     StringMap:
       type: "object"
       additionalProperties:

--- a/conjure-openapi/src/test/resources/object-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/object-test.openapi.yaml
@@ -7,13 +7,13 @@ components:
         - "required_reference_field"
       type: "object"
       properties:
-        optional_primitive_field:
-          type: "string"
-        optional_reference_field:
-          $ref: "#/components/schemas/PrimitiveObject"
         required_primitive_field:
           type: "string"
         required_reference_field:
+          $ref: "#/components/schemas/PrimitiveObject"
+        optional_primitive_field:
+          type: "string"
+        optional_reference_field:
           $ref: "#/components/schemas/PrimitiveObject"
     PrimitiveObject:
       required:
@@ -22,14 +22,14 @@ components:
         - "string_field"
       type: "object"
       properties:
-        double_field:
-          type: "number"
-          format: "float"
+        string_field:
+          type: "string"
         integer_field:
           type: "integer"
           format: "int32"
-        string_field:
-          type: "string"
+        double_field:
+          type: "number"
+          format: "float"
     ReferenceObject:
       required:
         - "primitive_field"

--- a/conjure-openapi/src/test/resources/union-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/union-test.openapi.yaml
@@ -12,12 +12,65 @@ components:
           format: "int32"
         fieldTwo:
           type: "string"
+    someIntegerWrapper:
+      required:
+        - "type"
+        - "someInteger"
+      type: "object"
+      properties:
+        type:
+          type: "string"
+        someInteger:
+          type: "integer"
+          format: "int32"
+    someObjectWrapper:
+      required:
+        - "type"
+        - "someObject"
+      type: "object"
+      properties:
+        type:
+          type: "string"
+        someObject:
+          $ref: "#/components/schemas/AnObject"
     ObjectUnion:
       discriminator:
         propertyName: "type"
       oneOf:
         - $ref: "#/components/schemas/someIntegerWrapper"
         - $ref: "#/components/schemas/someObjectWrapper"
+    doubleTypeWrapper:
+      required:
+        - "type"
+        - "doubleType"
+      type: "object"
+      properties:
+        type:
+          type: "string"
+        doubleType:
+          type: "number"
+          format: "float"
+    integerTypeWrapper:
+      required:
+        - "type"
+        - "integerType"
+      type: "object"
+      properties:
+        type:
+          type: "string"
+        integerType:
+          type: "integer"
+          format: "int32"
+    stringTypeWrapper:
+      required:
+        - "type"
+        - "stringType"
+      type: "object"
+      properties:
+        type:
+          type: "string"
+        stringType:
+          type: "string"
     PrimitiveUnion:
       discriminator:
         propertyName: "type"
@@ -25,56 +78,3 @@ components:
         - $ref: "#/components/schemas/doubleTypeWrapper"
         - $ref: "#/components/schemas/integerTypeWrapper"
         - $ref: "#/components/schemas/stringTypeWrapper"
-    doubleTypeWrapper:
-      required:
-        - "type"
-        - "doubleType"
-      type: "object"
-      properties:
-        doubleType:
-          type: "number"
-          format: "float"
-        type:
-          type: "string"
-    integerTypeWrapper:
-      required:
-        - "type"
-        - "integerType"
-      type: "object"
-      properties:
-        integerType:
-          type: "integer"
-          format: "int32"
-        type:
-          type: "string"
-    someIntegerWrapper:
-      required:
-        - "type"
-        - "someInteger"
-      type: "object"
-      properties:
-        someInteger:
-          type: "integer"
-          format: "int32"
-        type:
-          type: "string"
-    someObjectWrapper:
-      required:
-        - "type"
-        - "someObject"
-      type: "object"
-      properties:
-        someObject:
-          $ref: "#/components/schemas/AnObject"
-        type:
-          type: "string"
-    stringTypeWrapper:
-      required:
-        - "type"
-        - "stringType"
-      type: "object"
-      properties:
-        stringType:
-          type: "string"
-        type:
-          type: "string"


### PR DESCRIPTION
## Issue
Field order was not preserved previously.

## Summary
Uses ImmutableMap instead of TreeMap to preserve insertion order.

## Test Plan
Updates tests.