### PR TITLE
Add support for generating endpoint definitions

### DIFF
--- a/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/Mapper.java
+++ b/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/Mapper.java
@@ -1,0 +1,39 @@
+/*
+ * (c) Copyright 2022 Theorem Technology, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.theoremlp.conjure.openapi;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+
+public final class Mapper {
+    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory()
+                    .enable(Feature.INDENT_ARRAYS_WITH_INDICATOR)
+                    .disable(Feature.WRITE_DOC_START_MARKER))
+            .registerModule(new Jdk8Module())
+            .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .addMixIn(Schema.class, SchemaMixin.class)
+            .addMixIn(MediaType.class, SchemaMixin.class);
+
+    private Mapper() {}
+}

--- a/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ObjectGenerator.java
+++ b/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ObjectGenerator.java
@@ -18,7 +18,6 @@ package com.theoremlp.conjure.openapi;
 
 import com.google.common.collect.ImmutableMap;
 import com.palantir.conjure.spec.AliasDefinition;
-import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.EnumDefinition;
 import com.palantir.conjure.spec.EnumValueDefinition;
 import com.palantir.conjure.spec.FieldDefinition;
@@ -38,9 +37,9 @@ import java.util.stream.Stream;
 
 final class ObjectGenerator {
 
-    static Components generateComponents(ConjureDefinition conjureDefinition) {
+    static Components generateComponents(List<TypeDefinition> typeDefinitions) {
         return new Components()
-                .schemas(conjureDefinition.getTypes().stream()
+                .schemas(typeDefinitions.stream()
                         .flatMap(ObjectGenerator::convertTypeDefinition)
                         .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue)));
     }

--- a/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/OpenApiCli.java
+++ b/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/OpenApiCli.java
@@ -15,15 +15,8 @@
  */
 package com.theoremlp.conjure.openapi;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.palantir.conjure.spec.ConjureDefinition;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.media.Schema;
 import java.io.File;
 import java.io.IOException;
 import picocli.CommandLine;
@@ -49,14 +42,6 @@ public final class OpenApiCli implements Runnable {
             mixinStandardHelpOptions = true,
             usageHelpWidth = 120)
     public static final class GenerateCommand implements Runnable {
-        private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory()
-                        .enable(Feature.INDENT_ARRAYS_WITH_INDICATOR)
-                        .disable(Feature.WRITE_DOC_START_MARKER))
-                .registerModule(new Jdk8Module())
-                .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
-                .enable(SerializationFeature.INDENT_OUTPUT)
-                .addMixIn(Schema.class, SchemaMixin.class);
-
         @CommandLine.Parameters(paramLabel = "<input>", description = "Path to the input IR file", index = "0")
         private String input;
 
@@ -69,9 +54,10 @@ public final class OpenApiCli implements Runnable {
         @Override
         public void run() {
             try {
-                ConjureDefinition conjureDefinition = OBJECT_MAPPER.readValue(new File(input), ConjureDefinition.class);
+                ConjureDefinition conjureDefinition =
+                        Mapper.OBJECT_MAPPER.readValue(new File(input), ConjureDefinition.class);
                 OpenAPI api = OpenApiGenerator.generate(conjureDefinition);
-                OBJECT_MAPPER.writeValue(new File(output, "openapi.yaml"), api);
+                Mapper.OBJECT_MAPPER.writeValue(new File(output, "openapi.yaml"), api);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/OpenApiGenerator.java
+++ b/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/OpenApiGenerator.java
@@ -22,7 +22,9 @@ import io.swagger.v3.oas.models.OpenAPI;
 public final class OpenApiGenerator {
 
     static OpenAPI generate(ConjureDefinition conjureDefinition) {
-        return new OpenAPI().components(ObjectGenerator.generateComponents(conjureDefinition));
+        return new OpenAPI()
+                .components(ObjectGenerator.generateComponents(conjureDefinition.getTypes()))
+                .paths(ServiceGenerator.generatePaths(conjureDefinition.getServices()));
     }
 
     private OpenApiGenerator() {}

--- a/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ServiceGenerator.java
+++ b/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ServiceGenerator.java
@@ -1,0 +1,186 @@
+/*
+ * (c) Copyright 2022 Theorem Technology, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.theoremlp.conjure.openapi;
+
+import com.palantir.conjure.spec.ArgumentDefinition;
+import com.palantir.conjure.spec.AuthType;
+import com.palantir.conjure.spec.AuthType.Visitor;
+import com.palantir.conjure.spec.BodyParameterType;
+import com.palantir.conjure.spec.CookieAuthType;
+import com.palantir.conjure.spec.Documentation;
+import com.palantir.conjure.spec.EndpointDefinition;
+import com.palantir.conjure.spec.HeaderAuthType;
+import com.palantir.conjure.spec.HeaderParameterType;
+import com.palantir.conjure.spec.HttpPath;
+import com.palantir.conjure.spec.ParameterType;
+import com.palantir.conjure.spec.PathParameterType;
+import com.palantir.conjure.spec.QueryParameterType;
+import com.palantir.conjure.spec.ServiceDefinition;
+import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.spec.TypeName;
+import com.palantir.conjure.visitor.ParameterTypeVisitor;
+import com.palantir.conjure.visitor.TypeVisitor;
+import com.palantir.logsafe.Safe;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+final class ServiceGenerator {
+
+    public static final String BEARER_AUTH = "BearerAuth";
+
+    static Paths generatePaths(List<ServiceDefinition> services) {
+        Paths paths = new Paths();
+        services.stream().map(ServiceGenerator::generatePaths).forEach(paths::putAll);
+        return paths;
+    }
+
+    private static Map<String, PathItem> generatePaths(ServiceDefinition serviceDefinition) {
+        Map<HttpPath, List<EndpointDefinition>> endpointsByPath = serviceDefinition.getEndpoints().stream()
+                .collect(Collectors.groupingBy(EndpointDefinition::getHttpPath));
+        return endpointsByPath.entrySet().stream()
+                .collect(Collectors.toMap(entry -> entry.getKey().get(), entry -> {
+                    PathItem pathItem = new PathItem();
+                    entry.getValue().forEach(endpointDefinition -> {
+                        Operation operation = generateOperation(serviceDefinition.getServiceName(), endpointDefinition);
+                        switch (endpointDefinition.getHttpMethod().get()) {
+                            case GET -> pathItem.get(operation);
+                            case POST -> pathItem.post(operation);
+                            case PUT -> pathItem.put(operation);
+                            case DELETE -> pathItem.delete(operation);
+                            case UNKNOWN -> throw new IllegalStateException("Unexpected http method");
+                        }
+                    });
+                    return pathItem;
+                }));
+    }
+
+    private static Operation generateOperation(TypeName serviceName, EndpointDefinition endpointDefinition) {
+        Operation operation = new Operation();
+        operation
+                .operationId(serviceName.getName() + "#" + endpointDefinition.getEndpointName())
+                .deprecated(endpointDefinition.getDeprecated().isPresent());
+        endpointDefinition.getDocs().ifPresent(docs -> operation.setDescription(docs.get()));
+        endpointDefinition
+                .getAuth()
+                .map(ServiceGenerator::toSecurityRequirement)
+                .ifPresent(operation::addSecurityItem);
+        endpointDefinition.getArgs().stream()
+                .filter(arg -> !arg.getParamType().accept(ParameterTypeVisitor.IS_BODY))
+                .map(ServiceGenerator::toParameter)
+                .forEach(operation::addParametersItem);
+        endpointDefinition.getArgs().stream()
+                .filter(arg -> arg.getParamType().accept(ParameterTypeVisitor.IS_BODY))
+                .findFirst()
+                .ifPresent(arg -> operation.setRequestBody(toRequestBody(arg)));
+        endpointDefinition.getReturns().map(ServiceGenerator::toResponses).ifPresent(operation::setResponses);
+
+        return operation;
+    }
+
+    private static RequestBody toRequestBody(ArgumentDefinition arg) {
+        RequestBody requestBody = new RequestBody()
+                .required(true)
+                .content(new Content()
+                        .addMediaType(
+                                "application/json",
+                                new MediaType().schema(arg.getType().accept(ConjureTypeVisitor.INSTANCE))));
+        arg.getDocs().map(Documentation::get).ifPresent(requestBody::setDescription);
+
+        return requestBody;
+    }
+
+    private static Parameter toParameter(ArgumentDefinition argumentDefinition) {
+        Parameter parameter =
+                new Parameter().name(argumentDefinition.getArgName().get());
+        argumentDefinition.getDocs().map(Documentation::get).ifPresent(parameter::setDescription);
+
+        String location = argumentDefinition.getParamType().accept(new ParameterType.Visitor<String>() {
+            @Override
+            public String visitBody(BodyParameterType _value) {
+                throw new IllegalStateException("Should never happen");
+            }
+
+            @Override
+            public String visitHeader(HeaderParameterType value) {
+                return "header";
+            }
+
+            @Override
+            public String visitPath(PathParameterType value) {
+                return "path";
+            }
+
+            @Override
+            public String visitQuery(QueryParameterType value) {
+                return "query";
+            }
+
+            @Override
+            public String visitUnknown(@Safe String unknownType) {
+                throw new IllegalStateException("Unexpected type " + unknownType);
+            }
+        });
+        parameter.in(location);
+        parameter.setRequired(!argumentDefinition.getType().accept(TypeVisitor.IS_OPTIONAL));
+        parameter.setSchema(argumentDefinition.getType().accept(ConjureTypeVisitor.INSTANCE));
+
+        return parameter;
+    }
+
+    private static ApiResponses toResponses(Type type) {
+        return new ApiResponses()
+                .addApiResponse(
+                        "200",
+                        new ApiResponse()
+                                .content(new Content()
+                                        .addMediaType(
+                                                "application/json",
+                                                new MediaType().schema(type.accept(ConjureTypeVisitor.INSTANCE)))));
+    }
+
+    private static SecurityRequirement toSecurityRequirement(AuthType auth) {
+        return auth.accept(new Visitor<>() {
+            @Override
+            public SecurityRequirement visitHeader(HeaderAuthType value) {
+                return new SecurityRequirement().addList(BEARER_AUTH);
+            }
+
+            @Override
+            public SecurityRequirement visitCookie(CookieAuthType value) {
+                throw new IllegalStateException("Cookie auth is not supported");
+            }
+
+            @Override
+            public SecurityRequirement visitUnknown(String unknownType) {
+                throw new IllegalStateException("Unexpected auth type " + unknownType);
+            }
+        });
+    }
+
+    private ServiceGenerator() {}
+}

--- a/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ServiceGenerator.java
+++ b/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ServiceGenerator.java
@@ -126,17 +126,17 @@ final class ServiceGenerator {
             }
 
             @Override
-            public String visitHeader(HeaderParameterType value) {
+            public String visitHeader(HeaderParameterType _value) {
                 return "header";
             }
 
             @Override
-            public String visitPath(PathParameterType value) {
+            public String visitPath(PathParameterType _value) {
                 return "path";
             }
 
             @Override
-            public String visitQuery(QueryParameterType value) {
+            public String visitQuery(QueryParameterType _value) {
                 return "query";
             }
 
@@ -166,12 +166,12 @@ final class ServiceGenerator {
     private static SecurityRequirement toSecurityRequirement(AuthType auth) {
         return auth.accept(new Visitor<>() {
             @Override
-            public SecurityRequirement visitHeader(HeaderAuthType value) {
+            public SecurityRequirement visitHeader(HeaderAuthType _value) {
                 return new SecurityRequirement().addList(BEARER_AUTH);
             }
 
             @Override
-            public SecurityRequirement visitCookie(CookieAuthType value) {
+            public SecurityRequirement visitCookie(CookieAuthType _value) {
                 throw new IllegalStateException("Cookie auth is not supported");
             }
 

--- a/conjure-openapi/src/test/java/com/theoremlp/conjure/openapi/OpenApiGeneratorTest.java
+++ b/conjure-openapi/src/test/java/com/theoremlp/conjure/openapi/OpenApiGeneratorTest.java
@@ -35,8 +35,6 @@ class OpenApiGeneratorTest {
     @TempDir
     Path tempDir;
 
-    private void compareOutputsForPrefix(String prefix) throws IOException {}
-
     static List<String> getInputs() {
         try (Stream<Path> list = Files.list(Path.of("src/test/resources"))) {
             return list.filter(path -> path.getFileName().toString().endsWith("test.yml"))

--- a/conjure-openapi/src/test/java/com/theoremlp/conjure/openapi/SnapshotTesting.java
+++ b/conjure-openapi/src/test/java/com/theoremlp/conjure/openapi/SnapshotTesting.java
@@ -17,13 +17,10 @@ package com.theoremlp.conjure.openapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.io.CharStreams;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 public final class SnapshotTesting {
 
@@ -35,28 +32,11 @@ public final class SnapshotTesting {
         }
     }
 
-    public static String readFromResource(String path) {
-        try {
-            return CharStreams.toString(
-                    new InputStreamReader(SnapshotTesting.class.getResourceAsStream(path), StandardCharsets.UTF_8));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+    public static void validateGeneratorOutput(Path file, String content) throws IOException {
+        if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
+            Files.writeString(file, content);
         }
-    }
-
-    public static void validateGeneratorOutput(List<Path> files, Path outputDir) throws IOException {
-        validateGeneratorOutput(files, outputDir, "");
-    }
-
-    public static void validateGeneratorOutput(List<Path> files, Path outputDir, String suffix) throws IOException {
-        for (Path file : files) {
-            Path output = outputDir.resolve(file.getFileName() + suffix);
-            if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
-                Files.deleteIfExists(output);
-                Files.copy(file, output);
-            }
-            assertThat(readFromFile(file)).isEqualTo(readFromFile(output));
-        }
+        assertThat(readFromFile(file)).isEqualTo(content);
     }
 
     private SnapshotTesting() {}

--- a/conjure-openapi/src/test/resources/alias-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/alias-test.openapi.yaml
@@ -1,4 +1,5 @@
 openapi: "3.0.1"
+paths: {}
 components:
   schemas:
     BooleanAlias:

--- a/conjure-openapi/src/test/resources/enum-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/enum-test.openapi.yaml
@@ -1,4 +1,5 @@
 openapi: "3.0.1"
+paths: {}
 components:
   schemas:
     Enumeration:

--- a/conjure-openapi/src/test/resources/list-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/list-test.openapi.yaml
@@ -1,4 +1,5 @@
 openapi: "3.0.1"
+paths: {}
 components:
   schemas:
     DoubleList:

--- a/conjure-openapi/src/test/resources/map-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/map-test.openapi.yaml
@@ -1,4 +1,5 @@
 openapi: "3.0.1"
+paths: {}
 components:
   schemas:
     ObjectMap:

--- a/conjure-openapi/src/test/resources/object-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/object-test.openapi.yaml
@@ -1,4 +1,5 @@
 openapi: "3.0.1"
+paths: {}
 components:
   schemas:
     ObjectWithOptionals:

--- a/conjure-openapi/src/test/resources/service-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/service-test.openapi.yaml
@@ -1,0 +1,69 @@
+openapi: "3.0.1"
+paths:
+  /body:
+    post:
+      operationId: "ExampleService#body"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Body"
+        required: true
+      deprecated: false
+  /response:
+    get:
+      operationId: "ExampleService#response"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Body"
+      deprecated: false
+  /headers:
+    get:
+      operationId: "ExampleService#headers"
+      parameters:
+        - name: "header"
+          in: "header"
+          required: true
+          schema:
+            type: "string"
+      deprecated: false
+  /query:
+    get:
+      operationId: "ExampleService#queryParams"
+      parameters:
+        - name: "queryParam1"
+          in: "query"
+          required: true
+          schema:
+            type: "integer"
+            format: "int32"
+        - name: "queryParam2"
+          in: "query"
+          required: true
+          schema:
+            type: "string"
+      deprecated: false
+  /path/{param1}/{param2}:
+    get:
+      operationId: "ExampleService#pathParams"
+      parameters:
+        - name: "param1"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "param2"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      deprecated: false
+components:
+  schemas:
+    Body:
+      required: []
+      type: "object"
+      properties: {}

--- a/conjure-openapi/src/test/resources/service-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/service-test.openapi.yaml
@@ -2,6 +2,7 @@ openapi: "3.0.1"
 paths:
   /body:
     post:
+      description: "Endpoint documentation"
       operationId: "ExampleService#body"
       requestBody:
         content:

--- a/conjure-openapi/src/test/resources/service-test.yml
+++ b/conjure-openapi/src/test/resources/service-test.yml
@@ -13,6 +13,7 @@ services:
     default-auth: none
     endpoints:
       body:
+        docs: Endpoint documentation
         http: POST /body
         args:
           body: Body

--- a/conjure-openapi/src/test/resources/service-test.yml
+++ b/conjure-openapi/src/test/resources/service-test.yml
@@ -1,0 +1,46 @@
+types:
+  definitions:
+    default-package: com.theoremlp.test.openapi.api.v1
+    objects:
+      Body:
+        fields: {}
+
+services:
+  ExampleService:
+    name: Example service
+    package: com.theoremlp.test.openapi
+    base-path: /
+    default-auth: none
+    endpoints:
+      body:
+        http: POST /body
+        args:
+          body: Body
+
+      headers:
+        http: GET /headers
+        args:
+          header:
+            param-type: header
+            type: string
+            param-id: X-Theorem-Header
+
+      pathParams:
+        http: GET /path/{param1}/{param2}
+        args:
+          param1: string
+          param2: string
+
+      queryParams:
+        http: GET /query
+        args:
+          queryParam1:
+            param-type: query
+            type: integer
+          queryParam2:
+            param-type: query
+            type: string
+
+      response:
+        http: GET /response
+        returns: Body

--- a/conjure-openapi/src/test/resources/set-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/set-test.openapi.yaml
@@ -1,4 +1,5 @@
 openapi: "3.0.1"
+paths: {}
 components:
   schemas:
     DoubleSet:

--- a/conjure-openapi/src/test/resources/union-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/union-test.openapi.yaml
@@ -1,4 +1,5 @@
 openapi: "3.0.1"
+paths: {}
 components:
   schemas:
     AnObject:


### PR DESCRIPTION
## Issue
We would completely ignore any ServiceDefinitions in the ConjureDefinition when converting to openApi.

## Summary
Add support for generating endpoint definitions

Since OpenApi doesn't have an idea of a "service" (i.e. a logical grouping of endpoints) we end up flattining all endpoints from all services into the "paths" 

## Test Plan
