### PR TITLE
Support any type

### DIFF
--- a/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ConjurePrimitiveTypeVisitor.java
+++ b/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ConjurePrimitiveTypeVisitor.java
@@ -53,7 +53,7 @@ public final class ConjurePrimitiveTypeVisitor implements Visitor<Schema<?>> {
 
     @Override
     public Schema<?> visitAny() {
-        throw new IllegalStateException();
+        return new Schema<>();
     }
 
     @Override

--- a/conjure-openapi/src/test/resources/object-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/object-test.openapi.yaml
@@ -18,6 +18,7 @@ components:
           $ref: "#/components/schemas/PrimitiveObject"
     PrimitiveObject:
       required:
+        - "any_field"
         - "double_field"
         - "integer_field"
         - "string_field"
@@ -31,6 +32,7 @@ components:
         double_field:
           type: "number"
           format: "float"
+        any_field: {}
     ReferenceObject:
       required:
         - "primitive_field"

--- a/conjure-openapi/src/test/resources/object-test.yml
+++ b/conjure-openapi/src/test/resources/object-test.yml
@@ -7,6 +7,7 @@ types:
           string_field: string
           integer_field: integer
           double_field: double
+          any_field: any
       ReferenceObject:
         fields:
           primitive_field: string


### PR DESCRIPTION
## Issue
We would previously throw an Exception if we ever encountered an `any` type in a Conjure Def. It turns out that OpenAPI supports an [`AnyType`](https://swagger.io/docs/specification/data-models/data-types/#any), so we should too

## Summary
Support any type

## Test Plan
