### PR TITLE
Add support for binary field

### DIFF
--- a/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ConjurePrimitiveTypeVisitor.java
+++ b/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ConjurePrimitiveTypeVisitor.java
@@ -48,7 +48,7 @@ public final class ConjurePrimitiveTypeVisitor implements Visitor<Schema<?>> {
 
     @Override
     public Schema<?> visitBinary() {
-        throw new IllegalStateException();
+        return new Schema<>().type("string").format("byte");
     }
 
     @Override

--- a/conjure-openapi/src/test/resources/object-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/object-test.openapi.yaml
@@ -19,6 +19,7 @@ components:
     PrimitiveObject:
       required:
         - "any_field"
+        - "binary_field"
         - "double_field"
         - "integer_field"
         - "string_field"
@@ -33,6 +34,9 @@ components:
           type: "number"
           format: "float"
         any_field: {}
+        binary_field:
+          type: "string"
+          format: "byte"
     ReferenceObject:
       required:
         - "primitive_field"

--- a/conjure-openapi/src/test/resources/object-test.yml
+++ b/conjure-openapi/src/test/resources/object-test.yml
@@ -8,6 +8,7 @@ types:
           integer_field: integer
           double_field: double
           any_field: any
+          binary_field: binary
       ReferenceObject:
         fields:
           primitive_field: string


### PR DESCRIPTION
## Issue
We would previously throw an Exception if we ever encountered a `binary` type in a Conjure Def.  OpenApi has a `binary` [format](https://swagger.io/docs/specification/data-models/data-types/#format) which describes bytes as a base64 encoded string

## Summary
Add support for binary field

## Test Plan
