### PR TITLE
Generate union wrappers with strict type fields

### DIFF
--- a/conjure-openapi/src/test/resources/union-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/union-test.openapi.yaml
@@ -21,6 +21,8 @@ components:
       properties:
         type:
           type: "string"
+          enum:
+            - "someInteger"
         someInteger:
           type: "integer"
           format: "int32"
@@ -32,6 +34,8 @@ components:
       properties:
         type:
           type: "string"
+          enum:
+            - "someObject"
         someObject:
           $ref: "#/components/schemas/AnObject"
     ObjectUnion:
@@ -48,6 +52,8 @@ components:
       properties:
         type:
           type: "string"
+          enum:
+            - "doubleType"
         doubleType:
           type: "number"
           format: "float"
@@ -59,6 +65,8 @@ components:
       properties:
         type:
           type: "string"
+          enum:
+            - "integerType"
         integerType:
           type: "integer"
           format: "int32"
@@ -70,6 +78,8 @@ components:
       properties:
         type:
           type: "string"
+          enum:
+            - "stringType"
         stringType:
           type: "string"
     PrimitiveUnion:


### PR DESCRIPTION
## Issue
We would previously generate a "Wrapper" object for each union variant with a field "type" of type "string". Unfortunately, that caused openApi generators to break because the discriminator field was not sufficiently defined to allow the variant to be identified

## Summary
Generate union wrappers with strict type fields

## Test Plan
