### PR TITLE
Add support for external imports

### DIFF
--- a/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ConjureTypeVisitor.java
+++ b/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ConjureTypeVisitor.java
@@ -66,8 +66,8 @@ public enum ConjureTypeVisitor implements Type.Visitor<Schema<?>> {
     }
 
     @Override
-    public Schema<?> visitExternal(ExternalReference _value) {
-        throw new IllegalStateException();
+    public Schema<?> visitExternal(ExternalReference value) {
+        return value.getFallback().accept(this);
     }
 
     @Override

--- a/conjure-openapi/src/test/resources/object-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/object-test.openapi.yaml
@@ -2,6 +2,13 @@ openapi: "3.0.1"
 paths: {}
 components:
   schemas:
+    ExternalReferenceObject:
+      required:
+        - "externalField"
+      type: "object"
+      properties:
+        externalField:
+          type: "string"
     ObjectWithOptionals:
       required:
         - "required_primitive_field"

--- a/conjure-openapi/src/test/resources/object-test.yml
+++ b/conjure-openapi/src/test/resources/object-test.yml
@@ -1,4 +1,9 @@
 types:
+  imports:
+    JavaString:
+      base-type: string
+      external:
+        java: java.lang.String
   definitions:
     default-package: com.theoremlp.test.openapi.api.v1
     objects:
@@ -13,6 +18,9 @@ types:
         fields:
           primitive_field: string
           reference_field: PrimitiveObject
+      ExternalReferenceObject:
+        fields:
+          externalField: JavaString
       ObjectWithOptionals:
         fields:
           required_primitive_field: string


### PR DESCRIPTION
## Issue
We encountered an issue in generator openAPI definitions with conjure imports. Turns out that code path was never implemented

## Summary
Add support for external imports

## Test Plan
