### PR TITLE
Support non-unique variants

### DIFF
--- a/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ObjectGenerator.java
+++ b/conjure-openapi/src/main/java/com/theoremlp/conjure/openapi/ObjectGenerator.java
@@ -16,6 +16,8 @@
 
 package com.theoremlp.conjure.openapi;
 
+import com.google.common.base.CaseFormat;
+import com.google.common.base.Converter;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.EnumDefinition;
@@ -36,6 +38,8 @@ import java.util.Map.Entry;
 import java.util.stream.Stream;
 
 final class ObjectGenerator {
+    private static final Converter<String, String> LOWER_TO_UPPER_CAMEL =
+            CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.UPPER_CAMEL);
 
     static Components generateComponents(List<TypeDefinition> typeDefinitions) {
         return new Components()
@@ -112,7 +116,9 @@ final class ObjectGenerator {
                                             fieldDef.getType().accept(ConjureTypeVisitor.INSTANCE))
                                     .buildOrThrow();
                             return Map.entry(
-                                    fieldDef.getFieldName().get() + "Wrapper",
+                                    value.getTypeName().getName()
+                                            + LOWER_TO_UPPER_CAMEL.convert(
+                                                    fieldDef.getFieldName().get()) + "Wrapper",
                                     new Schema<>()
                                             .type("object")
                                             .properties(properties)

--- a/conjure-openapi/src/test/resources/union-test.openapi.yaml
+++ b/conjure-openapi/src/test/resources/union-test.openapi.yaml
@@ -13,7 +13,24 @@ components:
           format: "int32"
         fieldTwo:
           type: "string"
-    someIntegerWrapper:
+    AnotherUnionSomeObjectWrapper:
+      required:
+        - "type"
+        - "someObject"
+      type: "object"
+      properties:
+        type:
+          type: "string"
+          enum:
+            - "someObject"
+        someObject:
+          type: "string"
+    AnotherUnion:
+      discriminator:
+        propertyName: "type"
+      oneOf:
+        - $ref: "#/components/schemas/someObjectWrapper"
+    ObjectUnionSomeIntegerWrapper:
       required:
         - "type"
         - "someInteger"
@@ -26,7 +43,7 @@ components:
         someInteger:
           type: "integer"
           format: "int32"
-    someObjectWrapper:
+    ObjectUnionSomeObjectWrapper:
       required:
         - "type"
         - "someObject"
@@ -44,7 +61,7 @@ components:
       oneOf:
         - $ref: "#/components/schemas/someIntegerWrapper"
         - $ref: "#/components/schemas/someObjectWrapper"
-    doubleTypeWrapper:
+    PrimitiveUnionDoubleTypeWrapper:
       required:
         - "type"
         - "doubleType"
@@ -57,7 +74,7 @@ components:
         doubleType:
           type: "number"
           format: "float"
-    integerTypeWrapper:
+    PrimitiveUnionIntegerTypeWrapper:
       required:
         - "type"
         - "integerType"
@@ -70,7 +87,7 @@ components:
         integerType:
           type: "integer"
           format: "int32"
-    stringTypeWrapper:
+    PrimitiveUnionStringTypeWrapper:
       required:
         - "type"
         - "stringType"

--- a/conjure-openapi/src/test/resources/union-test.yml
+++ b/conjure-openapi/src/test/resources/union-test.yml
@@ -15,3 +15,7 @@ types:
         union:
           someObject: AnObject
           someInteger: integer
+
+      AnotherUnion:
+        union:
+          someObject: string


### PR DESCRIPTION
## Issue
There was a bug where if multiple distinct unions had variants with the same names we would emit multiple classes with the same name

## Summary
Support non-unique variants

## Test Plan
